### PR TITLE
Localization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 gem 'jekyll'
 group :jekyll_plugins do
-  gem 'jekyll-paginate'
   gem 'jekyll-archives'
+  gem 'jekyll-locale', git: 'https://github.com/ashmaroli/jekyll-locale.git', branch: 'master'
+  gem 'jekyll-paginate'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/ashmaroli/jekyll-locale.git
+  revision: dc5c46cadd09e3f13fb4c71b43aa082d90cca6a1
+  branch: master
+  specs:
+    jekyll-locale (0.5.1)
+      jekyll (>= 3.8, < 5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -66,4 +74,5 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-archives
+  jekyll-locale!
   jekyll-paginate

--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ Simple and readable openSUSE jekyll theme
 
 ## Development
 
+### How to set up environment?
+
+```bash
+sudo zypper in ruby ruby-devel
+bundle install --path vendor/bundle
+```
+
 ### How to build?
 
 ```bash
-bundle install --path vendor/bundle
 bundle exec jekyll build
 ```
 
@@ -18,7 +24,6 @@ Resulting site will be in `_site` directory.
 ### How to serve locally?
 
 ```bash
-bundle install --path vendor/bundle
 bundle exec jekyll serve
 ```
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,3 @@
-lang: en
 title: ""
 title_short: ""
 email: ""
@@ -6,6 +5,7 @@ description: ""
 copyright: '© 2020 openSUSE contributors'
 baseurl: ""
 url: ""
+weblate_url: "https://l10n.opensuse.org/"
 
 piwik_site_id: false
 
@@ -101,6 +101,7 @@ markdown: kramdown
 # paginate_path: '/page/:num/'
 # permalink: /:year/:month/:day/:title/
 
+# WARNING: jekyll-archives can not be used with jekyll-locale!!!
 # jekyll-archives:
 #   enabled: all
 #   layout: 'archive'
@@ -116,5 +117,23 @@ markdown: kramdown
 #     day: day-archive
 #     tag: cattag-archive
 #     category: cattag-archive
+
+# WARNING: jekyll-locale can not be used with jekyll-archives!!!
+localization:
+  mode       : auto
+  locale     : en
+  locales_set:
+    en:
+      name: English
+    es:
+      name: Español
+    fi:
+      name: Suomi
+    fr:
+      name: Français
+    zh-CN:
+      name: 简体中文
+    zh-TW:
+      name: 繁體中文
 
 exclude: [README.md, Gemfile, Gemfile.lock, vendor]

--- a/_data/locales/en.yaml
+++ b/_data/locales/en.yaml
@@ -1,0 +1,68 @@
+site_title: openSUSE News
+site_title_short: News
+site_description: Latest news from the openSUSE Project
+site_copyright: © 2011-2020 openSUSE contributors
+
+search: Search
+categories: Categories
+tags: Tags
+new_post: New Post
+translate: Translate
+subscribe: Subscribe
+
+source_code: Source Code
+privacy: Privacy
+
+share_this_post: Share this post
+
+locale_date:
+  date:
+    day_names:
+      - Sunday
+      - Monday
+      - Tuesday
+      - Wednesday
+      - Thursday
+      - Friday
+      - Saturday
+    month_names:
+      - ''
+      - January
+      - February
+      - March
+      - April
+      - May
+      - June
+      - July
+      - August
+      - September
+      - October
+      - November
+      - December
+    abbr_day_names:
+      - Sun
+      - Mon
+      - Tue
+      - Wed
+      - Thu
+      - Fri
+      - Sat
+    abbr_month_names:
+      - ''
+      - Jan
+      - Feb
+      - Mar
+      - Apr
+      - May
+      - Jun
+      - Jul
+      - Aug
+      - Sep
+      - Oct
+      - Nov
+      - Dec
+  time:
+    am: "am"
+    pm: "pm"
+    formats:
+      default: "%B %d, %Y"

--- a/_data/locales/zh-CN.yaml
+++ b/_data/locales/zh-CN.yaml
@@ -1,0 +1,68 @@
+site_title: openSUSE 新闻
+site_title_short: 新闻
+site_description: openSUSE 项目的最新动态
+site_copyright: © 2011-2020 openSUSE 贡献者
+
+search: 搜索
+categories: 分类
+tags: 标签
+new_post: 投稿
+translate: 翻译
+subscribe: 订阅
+
+source_code: 源码
+privacy: 隐私
+
+share_this_post: 分享文章
+
+locale_date:
+  date:
+    day_names:
+      - 星期日
+      - 星期一
+      - 星期二
+      - 星期三
+      - 星期四
+      - 星期五
+      - 星期六
+    month_names:
+      - ''
+      - 一月
+      - 二月
+      - 三月
+      - 四月
+      - 五月
+      - 六月
+      - 七月
+      - 八月
+      - 九月
+      - 十月
+      - 十一月
+      - 十二月
+    abbr_day_names:
+      - 周日
+      - 周一
+      - 周二
+      - 周三
+      - 周四
+      - 周五
+      - 周六
+    abbr_month_names:
+      - ''
+      - 一月
+      - 二月
+      - 三月
+      - 四月
+      - 五月
+      - 六月
+      - 七月
+      - 八月
+      - 九月
+      - 十月
+      - 十一月
+      - 十二月
+  time:
+    am: "上午"
+    pm: "下午"
+    formats:
+      default: "%Y 年%b %-d 日"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,11 +2,13 @@
   <div class="container">
     <div class="d-flex justify-content-between">
       <div class="footer-copyright">
-        {{ site.copyright }}
+        {{ locale.site_copyright | default: site.copyright }}
       </div>
       <div class="list-inline">
         {% for link in site.footer_links %}
-        <a class="list-inline-item" href="{{ link.link }}">{{ link.text }}</a>
+        <a class="list-inline-item" href="{{ link.link | prefix_locale }}">
+          {{ locale[link.text] | default: link.text }}
+        </a>
         {% endfor %}
       </div>
     </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,11 +3,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>
-    {% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape }}
+    {% if page.title %}
+    {{ page.title | escape }} -
+    {% endif %}
+    {{ locale.site_title | default: site.title | escape }}
   </title>
-
   <meta name="description"
-    content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+    content="{{ page.excerpt | default: locale.site_description | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="https://static.opensuse.org/chameleon-3.0/dist/css/chameleon.css">
@@ -33,10 +35,10 @@
   <meta name="theme-color" content="#73ba25">
 
   <!-- open graph meta -->
-  <meta property="og:site_name" content="{{ site.title | escape }}">
-  <meta property="og:title" content="{{ page.title | default: site.title | escape }}">
+  <meta property="og:site_name" content="{{ locale.site_title | default: site.title | escape }}">
+  <meta property="og:title" content="{{ page.title | default: locale.site_title | default: site.title | escape }}">
   <meta property="og:description"
-    content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+    content="{{ page.excerpt | default: locale.site_description | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
   <meta property=" og:url" content="{{ page.path | replace:'index.html','' | absolute_url }}">
   {% if page.layout == 'post' %}
   <meta property="og:type" content="article">
@@ -52,10 +54,10 @@
 
   <!-- twitter meta -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="{{ page.title | default: site.title | escape }}">
+  <meta name="twitter:title" content="{{ page.title | default: locale.site_title | default: site.title | escape }}">
   {% if page.layout == 'post' %}
   <meta name="twitter:description"
-    content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+    content="{{ page.excerpt | default: locale.site_description | default: site.description| strip_html | normalize_whitespace | truncate: 160 | escape }}">
   {% endif %}
   <meta name="twitter:url" content="{{ page.url | replace:'index.html','' | absolute_url }}">
   {% if page.image %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,9 +1,9 @@
 <nav class="navbar noprint {{ site.navbar_class | default: 'navbar-expand-md' }}">
 
-  <a class="navbar-brand" href="/">
+  <a class="navbar-brand" href="{{'/' | prefix_locale }}">
     <img src="https://static.opensuse.org/favicon.svg" class="d-inline-block align-top" alt="openSUSE" title="openSUSE"
       width="30" height="30">
-    <span class="navbar-title">{{ site.title_short }}</span>
+    <span class="navbar-title">{{ locale.site_title_short | default: site.title_short }}</span>
   </a>
 
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-collapse">
@@ -32,7 +32,7 @@
             <path
               d="M2 3h10v2H2V3zm0 3h4v3H2V6zm0 4h4v1H2v-1zm0 2h4v1H2v-1zm5-6h2v1H7V6zm3 0h2v1h-2V6zM7 8h2v1H7V8zm3 0h2v1h-2V8zm-3 2h2v1H7v-1zm3 0h2v1h-2v-1zm-3 2h2v1H7v-1zm3 0h2v1h-2v-1z" />
           </svg>
-          {{ site.messages.categories }}
+          {{ locale.categories }}
         </a>
         <div class="dropdown-menu" aria-labelledby="cat-menu-link">
           {% for category in site.categories %}
@@ -44,20 +44,58 @@
         </div>
       </li>
 
+      {% elsif link == 'locales' %}
+
+      <!-- Locales Dropdown -->
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="locale-menu-link" role="button" data-toggle="dropdown"
+          aria-haspopup="true" aria-expanded="false">
+          <svg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 512 512'>
+            <line x1='48' y1='112' x2='336' y2='112'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+            <line x1='192' y1='64' x2='192' y2='112'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+            <polyline points='272 448 368 224 464 448'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+            <line x1='301.5' y1='384' x2='434.5' y2='384'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+            <path d='M281.3,112S257,206,199,277,80,384,80,384'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+            <path d='M256,336s-35-27-72-75-56-85-56-85'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+          </svg>
+          {{ page.locale.name }}
+        </a>
+        <div class="dropdown-menu" aria-labelledby="cat-menu-link">
+          {% for ref in page.locale_siblings %}
+          <a class="dropdown-item" href="{{ ref.url | relative_url }}">
+            {{ ref.locale.name }}
+          </a>
+          {% endfor %}
+          <div class="dropdown-divider"></div>
+          <a class="dropdown-item" href="{{ site.weblate_url }}">
+            {{ locale.translate }}
+          </a>
+        </div>
+      </li>
+
       {% elsif link.children %}
 
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true"
           aria-expanded="false">
           {{ link.icon }}
-          {{ link.text }}
+          {{ locale[link.text] | default: link.text }}
         </a>
         <div class="dropdown-menu">
           {% for child in link.children %}
           {% if child == 'divider' %}
           <div class="dropdown-divider"></div>
           {% else %}
-          <a class="dropdown-item" href="{{ child.link | prefix_locale }}">{{ child.icon }} {{ child.text }}</a>
+          <a class="dropdown-item" href="{{ child.link | prefix_locale }}">
+            {{ child.icon }}
+            {{ locale[child.text] | default: child.text }}
+          </a>
           {% endif %}
           {% endfor %}
         </div>
@@ -66,9 +104,9 @@
       {% else %}
 
       <li class="nav-item{%if link.link == page.url%} active{%endif%}">
-        <a class="nav-link" href="{{ link.link }}">
+        <a class="nav-link" href="{{ link.link | prefix_locale }}">
           {{ link.icon }}
-          {{ link.text }}
+          {{ locale[link.text] | default: link.text }}
         </a>
       </li>
       {% endif %}
@@ -80,7 +118,7 @@
     <!-- GitHub Search -->
     <form class="form-inline mr-md-3" action="https://github.com/{{ site.search_github_repo }}/search">
       <div class="input-group">
-        <input class="form-control" type="search" name="q" placeholder="Search" lang="en">
+        <input class="form-control" type="search" name="q" placeholder="{{ locale.search }}" lang="en">
         <input type="hidden" name="l" value="Markdown">
         <input type="hidden" name="s" value="indexed">
         <div class="input-group-append">
@@ -101,7 +139,7 @@
     <!-- DuckDuckGo Search -->
     <form id="ddg-form" class="form-inline mr-md-3" action="https://duckduckgo.com/">
       <div class="input-group">
-        <input id="ddg-input" class="form-control" type="search" name="q" placeholder="Search" lang="en">
+        <input id="ddg-input" class="form-control" type="search" name="q" placeholder="{{ locale.search }}" lang="en">
         <div class="input-group-append">
           <button class="btn btn-secondary" type="submit">
             <svg class="bi bi-search" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
+<html lang="{{ page.locale.id | default: page.lang | default: site.lang }}">
 
 {% include head.html %}
 

--- a/jekyll-theme-opensuse.gemspec
+++ b/jekyll-theme-opensuse.gemspec
@@ -8,11 +8,11 @@ Gem::Specification.new do |spec|
     spec.homepage = "https://github.com/openSUSE/jekyll-theme"
     spec.license  = "GPL-3.0-or-later"
 
-    spec.files    = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(_includes|_layouts|assets|category|feed|tag|CHANGELOG|LICENSE|README)!i) }
+    spec.files    = `git ls-files -z`.split('\x0').select { |f| f.match(%r!^(_data|_includes|_layouts|assets|category|feed|tag|CHANGELOG|LICENSE|README)!i) }
 
-    spec.add_runtime_dependency "jekyll"
-    spec.add_runtime_dependency "jekyll-paginate"
-    spec.add_runtime_dependency "jekyll-archives"
+    spec.add_runtime_dependency 'jekyll'
+    spec.add_runtime_dependency 'jekyll-archives'
+    spec.add_runtime_dependency 'jekyll-paginate'
 
-    spec.add_development_dependency "bundler"
+    spec.add_development_dependency 'bundler'
 end

--- a/manifest.json
+++ b/manifest.json
@@ -1,3 +1,19 @@
 ---
 ---
-{"name":"{{ site.title | escape }}","short_name":"{{ site.title | escape }}","description":"{{ site.description | escape }}","background_color":"#ffffff","theme_color":"#73ba25","start_url":".","scope":"/","display":"standalone","icons":[{"src":"{{ "/assets/favicons/favicon.png" | absolute_url }}","sizes":"196x196","type":"image/png"}]}
+{
+  "name": "{{ locale.site_title | escape }}",
+  "short_name": "{{ locale.site_title | escape }}",
+  "description": "{{ locale.site_description | escape }}",
+  "background_color": "#ffffff",
+  "theme_color": "#73ba25",
+  "start_url": ".",
+  "scope": "/",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "{{ "/assets/favicons/favicon.png" | absolute_url }}",
+      "sizes": "196x196",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
`jekyll-locale` based solution.

Take French as example, UI strings are stored in `_data/locales/fr.yaml`. Pages and posts are stored in `_locales/fr/` folders. The site url will be prefixed with `/fr/`.

![image](https://user-images.githubusercontent.com/5836790/80572812-90fb1680-8a07-11ea-8f67-4f5aee1fc825.png)

In general, it works. But when rendering archives, only English site has posts (mixed with other language posts, but I filtered them), and other language sites don't show anything at home page, category page, etc.

For sites without archive, like doc.o.o, search.o.o, it is ready to go.

But for news.o.o, it is not good enough for production.