### PR TITLE
new breadcrumb icon option type

### DIFF
--- a/_layouts/cattag-archive.html
+++ b/_layouts/cattag-archive.html
@@ -5,9 +5,7 @@ layout: default
 	<li class="breadcrumb-item">
 		<a href="{{ site.baseurl }}/">
 			{% if site.breadcrumb_icon %}
-			<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-				<path d="{{ site.breadcrumb_icon }}" />
-			</svg>
+			{{ site.breadcrumb_icon }}
 			{% endif %}
 			{{ site.title_short }}
 		</a>

--- a/_layouts/day-archive.html
+++ b/_layouts/day-archive.html
@@ -5,9 +5,7 @@ layout: default
 	<li class="breadcrumb-item">
 		<a href="{{ site.baseurl }}/">
 			{% if site.breadcrumb_icon %}
-			<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-				<path d="{{ site.breadcrumb_icon }}" />
-			</svg>
+			{{ site.breadcrumb_icon }}
 			{% endif %}
 			{{ site.title_short }}
 		</a>

--- a/_layouts/month-archive.html
+++ b/_layouts/month-archive.html
@@ -5,9 +5,7 @@ layout: default
 	<li class="breadcrumb-item">
 		<a href="{{ site.baseurl }}/">
 			{% if site.breadcrumb_icon %}
-			<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-				<path d="{{ site.breadcrumb_icon }}" />
-			</svg>
+			{{ site.breadcrumb_icon }}
 			{% endif %}
 			{{ site.title_short }}
 		</a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,9 +5,7 @@ layout: default
 	<li class="breadcrumb-item">
 		<a href="{{ site.baseurl }}/">
 			{% if site.breadcrumb_icon %}
-			<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-				<path d="{{ site.breadcrumb_icon }}" />
-			</svg>
+			{{ site.breadcrumb_icon }}
 			{% endif %}
 			{{ site.title_short }}
 		</a>

--- a/_layouts/year-archive.html
+++ b/_layouts/year-archive.html
@@ -5,9 +5,7 @@ layout: default
 	<li class="breadcrumb-item">
 		<a href="{{ site.baseurl }}/">
 			{% if site.breadcrumb_icon %}
-			<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-				<path d="{{ site.breadcrumb_icon }}" />
-			</svg>
+			{{ site.breadcrumb_icon }}
 			{% endif %}
 			{{ site.title_short }}
 		</a>

--- a/category/index.html
+++ b/category/index.html
@@ -5,9 +5,7 @@ layout: default
 	<li class="breadcrumb-item">
 		<a href="{{ site.baseurl }}/">
 			{% if site.breadcrumb_icon %}
-			<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-				<path d="{{ site.breadcrumb_icon }}" />
-			</svg>
+			{{ site.breadcrumb_icon }}
 			{% endif %}
 			{{ site.title_short }}
 		</a>

--- a/jekyll-theme-opensuse.gemspec
+++ b/jekyll-theme-opensuse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
     spec.name     = "jekyll-theme-opensuse"
-    spec.version  = "0.4.0"
+    spec.version  = "0.5.0"
     spec.authors  = ["Stasiek Michalski", "Guo Yunhe"]
     spec.summary  = "Jekyll theme for openSUSE websites"
     spec.homepage = "https://github.com/openSUSE/jekyll-theme"

--- a/tag/index.html
+++ b/tag/index.html
@@ -5,9 +5,7 @@ layout: default
 	<li class="breadcrumb-item">
 		<a href="{{ site.baseurl }}/">
 			{% if site.breadcrumb_icon %}
-			<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-				<path d="{{ site.breadcrumb_icon }}" />
-			</svg>
+			{{ site.breadcrumb_icon }}
 			{% endif %}
 			{{ site.title_short }}
 		</a>


### PR DESCRIPTION
When using new bootstrap icons, we have to pass full svg of the icon, instead of the path.