### PR TITLE
Allow more class for navbar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ defaults:
 #     link: /feed/
 #     text: RSS Feed
 
-# navbar_sticky: true
+# navbar_class: navbar-expand-md sticky-top
 # enable_feed: true
 
 # breadcrumb_icon: <svg class="bi bi-newspaper" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M0 2A1.5 1.5 0 0 1 1.5.5h11A1.5 1.5 0 0 1 14 2v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14V2zm1.5-.5A.5.5 0 0 0 1 2v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5V2a.5.5 0 0 0-.5-.5h-11z"/><path fill-rule="evenodd" d="M15.5 3a.5.5 0 0 1 .5.5V14a1.5 1.5 0 0 1-1.5 1.5h-3v-1h3a.5.5 0 0 0 .5-.5V3.5a.5.5 0 0 1 .5-.5z"/><path d="M2 3h10v2H2V3zm0 3h4v3H2V6zm0 4h4v1H2v-1zm0 2h4v1H2v-1zm5-6h2v1H7V6zm3 0h2v1h-2V6zM7 8h2v1H7V8zm3 0h2v1h-2V8zm-3 2h2v1H7v-1zm3 0h2v1h-2v-1zm-3 2h2v1H7v-1zm3 0h2v1h-2v-1z"/></svg>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-md noprint{% if site.navbar_sticky %} sticky-top{% endif %}">
+<nav class="navbar noprint {{ site.navbar_class}}">
 
   <a class="navbar-brand" href="/">
     <img src="https://static.opensuse.org/favicon.svg" class="d-inline-block align-top" alt="openSUSE" title="openSUSE"


### PR DESCRIPTION
In this way, we allow more options for navbar, like `sticky-top`, `fixed-top`, `navbar-expand-md`, `navbar-expand-lg`.