### PR TITLE
Rss thumbnail

### DIFF
--- a/_layouts/rss20.xml
+++ b/_layouts/rss20.xml
@@ -14,6 +14,7 @@
       <pubDate>{{ post.date | date_to_xmlschema }}</pubDate>
       <link>{{ site.url }}{{ post.url }}</link>
       <description>{{ post.excerpt | strip_html | xml_escape | truncatewords: 50 }}</description>
+      <enclosure url="{{ post.image }}"/>
       <content:encoded>{{ post.content | xml_escape }}</content:encoded>
     </item>
 {% endfor %}

--- a/jekyll-theme-opensuse.gemspec
+++ b/jekyll-theme-opensuse.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
     spec.name     = "jekyll-theme-opensuse"
-    spec.version  = "0.6.1"
+    spec.version  = "0.7.0"
     spec.authors  = ["Stasiek Michalski", "Guo Yunhe"]
     spec.summary  = "Jekyll theme for openSUSE websites"
     spec.homepage = "https://github.com/openSUSE/jekyll-theme"


### PR DESCRIPTION
According to RSS 2.0 standard, `<enclosure/>` is the closest thing we can use for the thumbnail image.
https://www.rssboard.org/rss-specification#ltenclosuregtSubelementOfLtitemgt

With this, we can show more rich featured cards in www.opensuse.org