### PR TITLE
Allow full jquery, extra head and footer content override.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -61,6 +61,9 @@ defaults:
 # navbar_class: navbar-expand-md sticky-top
 # enable_feed: true
 
+# if you want to use $.ajax()
+# jquery_full: true
+
 # breadcrumb_icon: <svg class="bi bi-newspaper" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M0 2A1.5 1.5 0 0 1 1.5.5h11A1.5 1.5 0 0 1 14 2v12a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 0 14V2zm1.5-.5A.5.5 0 0 0 1 2v12a.5.5 0 0 0 .5.5h11a.5.5 0 0 0 .5-.5V2a.5.5 0 0 0-.5-.5h-11z"/><path fill-rule="evenodd" d="M15.5 3a.5.5 0 0 1 .5.5V14a1.5 1.5 0 0 1-1.5 1.5h-3v-1h3a.5.5 0 0 0 .5-.5V3.5a.5.5 0 0 1 .5-.5z"/><path d="M2 3h10v2H2V3zm0 3h4v3H2V6zm0 4h4v1H2v-1zm0 2h4v1H2v-1zm5-6h2v1H7V6zm3 0h2v1h-2V6zM7 8h2v1H7V8zm3 0h2v1h-2V8zm-3 2h2v1H7v-1zm3 0h2v1h-2v-1zm-3 2h2v1H7v-1zm3 0h2v1h-2v-1z"/></svg>
 
 date_format: '%-d. %b %Y'

--- a/_includes/footer-extra.html
+++ b/_includes/footer-extra.html
@@ -1,0 +1,1 @@
+<!-- Extra Footer Content -->

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,3 +14,5 @@
     </div>
   </div>
 </footer>
+
+{% include footer-extra.html %}

--- a/_includes/head-extra.html
+++ b/_includes/head-extra.html
@@ -1,0 +1,1 @@
+<!-- Extra Head Content -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -67,7 +67,8 @@
   {% endif %}
 
   <!-- javascript -->
-  <script defer src="https://static.opensuse.org/chameleon-3.0/dist/js/jquery.slim.js"></script>
+  <script defer
+    src="https://static.opensuse.org/chameleon-3.0/dist/js/jquery{{ site.jquery_full ? '' : '.slim' }}.js"></script>
   <script defer src="https://static.opensuse.org/chameleon-3.0/dist/js/bootstrap.bundle.js"></script>
   <script defer src="https://static.opensuse.org/chameleon-3.0/dist/js/chameleon.js"></script>
 
@@ -102,4 +103,6 @@
   {% endif %}
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
+
+  {% include head-extra.html %}
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -67,8 +67,11 @@
   {% endif %}
 
   <!-- javascript -->
-  <script defer
-    src="https://static.opensuse.org/chameleon-3.0/dist/js/jquery{{ site.jquery_full ? '' : '.slim' }}.js"></script>
+  {% if site.jquery_full %}
+  <script defer src="https://static.opensuse.org/chameleon-3.0/dist/js/jquery.js"></script>
+  {% else %}
+  <script defer src="https://static.opensuse.org/chameleon-3.0/dist/js/jquery.slim.js"></script>
+  {% endif %}
   <script defer src="https://static.opensuse.org/chameleon-3.0/dist/js/bootstrap.bundle.js"></script>
   <script defer src="https://static.opensuse.org/chameleon-3.0/dist/js/chameleon.js"></script>
 


### PR DESCRIPTION
If you just want to use full jquery:

```yaml
# _config.yml
jquery_full: true
```

If you want to add more scripts and styles in `<head>`, create `_includes/head-extra.html`:

```html
<script src="..."></script>
```

If you want to add more stuff at the end of `<body>`, create `_includes/footer-extra.html`:


```html
<template>...</template>
```

Fix #29 