### PR TITLE
_config.yml: Do not predefine languages that may not exist

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -128,15 +128,5 @@ localization:
   locales_set:
     en:
       name: English
-    es:
-      name: Español
-    fi:
-      name: Suomi
-    fr:
-      name: Français
-    zh-CN:
-      name: 简体中文
-    zh-TW:
-      name: 繁體中文
 
 exclude: [README.md, Gemfile, Gemfile.lock, vendor]


### PR DESCRIPTION
Downstream on doc.opensuse.org these lines cause us to generate languages
like Finnish and Traditional Chinese for which we don't actually have site
translations available.